### PR TITLE
[ADD] Raw SubCommand

### DIFF
--- a/Plugins/Tags/Commands/TagCommand.ts
+++ b/Plugins/Tags/Commands/TagCommand.ts
@@ -15,8 +15,10 @@ import {
   RunListSubCommand,
   RunShowSubCommand,
   RunUseSubCommand,
+  RunRawSubCommand,
   ShowSubCommand,
-  UseSubCommand
+  UseSubCommand,
+  RawSubCommand,
 } from "../SubCommands";
 import { CheckForRoles } from "../../../Common/CheckForRoles";
 import { TagGet } from "../Controllers/TagGet";
@@ -29,6 +31,7 @@ const subCommands: ApplicationCommandOptions[] = [
   ShowSubCommand,
   InfoSubCommand,
   UseSubCommand,
+  RawSubCommand,
 ];
 
 export = {
@@ -76,6 +79,9 @@ export = {
           case 'use':
             await RunUseSubCommand(ctx, interaction);
             break;
+          case 'raw':
+            await RunRawSubCommand(ctx, interaction);
+            break;
         }
       } else {
         return interaction.reply({
@@ -104,6 +110,9 @@ export = {
           break;
         case 'info':
           await RunInfoSubCommand(ctx, interaction);
+          break;
+        case 'raw':
+          await RunRawSubCommand(ctx, interaction);
           break;
         default:
           return interaction.respond([]);

--- a/Plugins/Tags/SubCommands/RawSubCommand.ts
+++ b/Plugins/Tags/SubCommands/RawSubCommand.ts
@@ -1,0 +1,86 @@
+import { ApplicationCommandOptions, ApplicationCommandOptionType } from "@antibot/interactions";
+import { Context } from "../../../Source/Context";
+import { RegisterSubCommand } from "../../../Common/RegisterSubCommand";
+import { AttachmentBuilder, AutocompleteInteraction, ChatInputCommandInteraction } from "discord.js";
+import { TagExists } from "../Controllers/TagExists";
+import { TagGet } from "../Controllers/TagGet";
+import { TagsGet } from "../Controllers/TagsGet";
+
+export const RawSubCommand: ApplicationCommandOptions = {
+    name: "raw",
+    description: "Get the raw content of a tag as a text attachment file.",
+    type: ApplicationCommandOptionType.SUB_COMMAND,
+    options: [
+        {
+            name: "tag-name",
+            description: "Provide the name of the tag you would like to get as text attachment file!",
+            type: ApplicationCommandOptionType.STRING,
+            required: true,
+            autocomplete: true
+        }
+    ]
+} as ApplicationCommandOptions;
+
+export async function RunRawSubCommand(ctx: Context, interaction: ChatInputCommandInteraction | AutocompleteInteraction) {
+    await RegisterSubCommand({
+        subCommand: "raw",
+        ctx: ctx,
+        interaction: interaction,
+        callback: async (ctx: Context, interaction: ChatInputCommandInteraction) => {
+            try {
+                const tagName: string = interaction.options.getString("tag-name");
+
+                if (await TagExists({ guildId: interaction.guild.id, name: tagName, ctx: ctx })) {
+                    const getTag = await TagGet({ name: tagName, guildId: interaction.guild.id, ctx: ctx });
+
+                    const separator = "—————————————————————————————————————————";
+                    const fileContent = [
+                        separator.repeat(2),
+                        "TAG NAME:",
+                        getTag.TagName || "None",
+                        separator.repeat(2),
+                        "TAG TITLE:",
+                        getTag.TagEmbedTitle || "None",
+                        separator.repeat(2),
+                        "TAG DESCRIPTION:",
+                        getTag.TagEmbedDescription || "None",
+                        separator.repeat(2),
+                        "TAG IMAGE URL:",
+                        getTag.TagEmbedImageURL || "None",
+                        separator.repeat(2),
+                        "TAG FOOTER:",
+                        getTag.TagEmbedFooter || "None",
+                        separator.repeat(2),
+                    ].join("\n");
+
+                    const attachment = new AttachmentBuilder(Buffer.from(fileContent, "utf-8"), {
+                        name: `${getTag.TagName}.txt`,
+                    });
+
+                    return interaction.reply({
+                        content: `Here is the raw content of the tag \`${tagName}\`:`,
+                        files: [attachment],
+                        ephemeral: true,
+                    });
+                } else {
+                    return interaction.reply({ content: `> The tag \`${tagName}\` doesn't exist!`, ephemeral: true, });
+                }
+            }
+            catch (error) {
+                console.error(error.stack);
+            }
+        },
+        autocomplete: async (ctx, interaction) => {
+            const focus = interaction.options.getFocused();
+            const tags = await TagsGet(interaction.guild.id, ctx);
+
+            const filteredTags = focus.length > 0 ? tags.filter((x) => x.TagName.toLowerCase().includes(focus.toLowerCase())) : tags;
+            await interaction.respond(
+                filteredTags.map((x) => ({
+                    name: x.TagName,
+                    value: x.TagName,
+                })).slice(0, 20)
+            );
+        },
+    });
+}

--- a/Plugins/Tags/SubCommands/index.ts
+++ b/Plugins/Tags/SubCommands/index.ts
@@ -5,3 +5,4 @@ export * from "./EditSubCommand";
 export * from "./ShowSubCommand";
 export * from "./InfoSubCommand";
 export * from "./UseSubCommand";
+export * from "./RawSubCommand";


### PR DESCRIPTION
This subcommand allows users to retrieve an embedded tag as a .txt file attachment.

The selected tag, fetched from the database, is converted into a formatted string. This string is then buffered (stored temporarily in memory without saving to the device) into a text file and sent to Discord as an ephemeral message, with the file included as an attachment.

I choosed to use attachment and not an code block because if the tag's description contains a code block, it would break the formatting of the main code block in Discord.

Preview:
![image](https://github.com/user-attachments/assets/d3b74c56-254f-43d3-8174-bdc5c25b37cd)
