### PR TITLE
[ADD] Add safeguard to prevent exceeding Discord's tag limit when applying "Resolved" tag

### DIFF
--- a/Plugins/Tags/Commands/ResolveCommand.ts
+++ b/Plugins/Tags/Commands/ResolveCommand.ts
@@ -37,15 +37,9 @@ export = {
                 const appliedTags = (interaction.channel as any).appliedTags;
                 if (interaction.channel.type == ChannelType.PublicThread) {
                     if (appliedTags.length >= 5) {
-                        return interaction.reply({
-                            content:
-                                "This thread already has 5 tags applied.\nPlease remove one tag before executing `/resolve` again!",
-                            ephemeral: true,
-                        });
+                        return interaction.reply({ content: "This thread already has 5 tags applied.\nPlease remove one tag before executing `/resolve` again!", ephemeral: true });
                     }
-
-                    // TODO: Use Enviroment Variables to specify the "Resolved" and "Waiting for Update" tag ids
-                    // TODO: Instead hardcoding the ids.
+                  
                     if (!appliedTags.includes("1144008960966402149")) {
                         const tagIndex = appliedTags.indexOf("1284733312501420145");
                         if (tagIndex !== -1) {
@@ -80,17 +74,10 @@ export = {
                     }
                     return;
                 } else {
-                    return interaction.reply({
-                        content:
-                            "Channel is not a thread. This command **must be** executed in Forum Posts!",
-                        ephemeral: true,
-                    });
+                    return interaction.reply({ content: "Channel is not a thread. This command **must be** executed in Forum Posts!",ephemeral: true });
                 }
             }
-            return interaction.reply({
-                content: "Sorry but you can't use this command.",
-                ephemeral: true,
-            });
+            return interaction.reply({ content: "Sorry but you can't use this command.", ephemeral: true });
         },
     })
 }


### PR DESCRIPTION
---
- Implemented a validation to ensure the thread does not exceed Discord's maximum tag limit (5 tags) before applying the "Resolved" tag, with a warning to the user to remove one tag if the total tags applied to the thread reach or exceed 5:
https://github.com/GuikiPT/jasper-fork/blob/0002e1c80ce56d26dcd9e46f01b1444a912f6de2/Plugins/Tags/Commands/ResolveCommand.ts?plain=1#L37-L49
---
- Also fixed code indent, so ignore the long modified lines that these push is doing, the important lines are mentioned above.

---
- Furthermore, I added just a `// TODO` comment to remember in the future to work in a implementation, since the ids of the tags that are hardcoded, I will see if I'm able to replace in with a `ctx.env.get(...)` (.env file) with the ids specified by environment variables or either using some short of command under `Settings` plugin that uses mongodb some config table to add, edit or remove tag ids from there.

Any suggestion of how to implement it just lemme know.
