### PR TITLE
[FIX] Interaction filter for ModalSubmit not working correctly.

### DIFF
--- a/Plugins/Tags/Modals/TagEditModal.ts
+++ b/Plugins/Tags/Modals/TagEditModal.ts
@@ -12,46 +12,49 @@ export = {
             once: false
         },
         on: async (interaction: ModalSubmitInteraction, ctx: Context) => {
-            if (interaction.customId === `tag_edit_${interaction.user.id}`) {
-                if (!interaction.isModalSubmit()) {
-                    return;
+            try {
+                if (interaction.customId === `tag_edit_${interaction.user.id}`) {
+                    if (!interaction.isModalSubmit()) return;
+                    
+                    const name = interaction.fields.getTextInputValue("tag_edit_embed_name");
+                    const title = interaction.fields.getTextInputValue("tag_edit_embed_title");
+                    const editedBy = interaction.user.id;
+                    const description = interaction.fields.getTextInputValue("tag_edit_embed_description");
+                    const image_url = interaction.fields.getTextInputValue("tag_edit_embed_image_url");
+                    const footer = interaction.fields.getTextInputValue("tag_edit_embed_footer");
+
+                    const guildId = interaction.guild.id;
+
+                    if (!(await ctx.services.tags.itemExists<Options>({ guildId, name }))) {
+                        return interaction.reply({ content: `> The support tag \`${name}\` doesn't exist!`, flags: MessageFlags.Ephemeral });
+                    }
+
+                    if (image_url && !/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i.test(image_url)) {
+                        return interaction.reply({ content: `> The provided image link is not a valid image URL!`, flags: MessageFlags.Ephemeral });
+                    }
+
+                    await ctx.services.tags.modify<Options & { tag?: Tag }, void>({ guildId, name, tag: { name, title, editedBy, description, image_url, footer } });
+
+                    const { TagEmbedTitle, TagEmbedDescription, TagEmbedImageURL, TagEmbedFooter } = await ctx.services.tags.getValues<Options, TagResponse>({ guildId, name });
+
+                    return interaction.reply({
+                        content: `${Emojis.CHECK_MARK} Successfully edited \`${name}\`!`,
+                        embeds: [
+                            {
+                                title: TagEmbedTitle,
+                                color: 0x323338,
+                                description: TagEmbedDescription,
+                                image: { url: TagEmbedImageURL ?? undefined },
+                                footer: { text: TagEmbedFooter }
+                            }
+                        ],
+                        flags: MessageFlags.Ephemeral
+                    })
                 }
             }
-
-            const name = interaction.fields.getTextInputValue("tag_edit_embed_name");
-            const title = interaction.fields.getTextInputValue("tag_edit_embed_title");
-            const editedBy = interaction.user.id;
-            const description = interaction.fields.getTextInputValue("tag_edit_embed_description");
-            const image_url = interaction.fields.getTextInputValue("tag_edit_embed_image_url");
-            const footer = interaction.fields.getTextInputValue("tag_edit_embed_footer");
-
-            const guildId = interaction.guild.id;
-
-            if (!(await ctx.services.tags.itemExists<Options>({ guildId, name }))) {
-                return interaction.reply({ content: `> The support tag \`${name}\` doesn't exist!`, flags: MessageFlags.Ephemeral });
+            catch (error) {
+                throw ('Error on TagEditModal ' + error.stack || error);
             }
-
-            if (image_url && !/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i.test(image_url)) {
-                return interaction.reply({ content: `> The provided image link is not a valid image URL!`, flags: MessageFlags.Ephemeral });
-            }
-
-            await ctx.services.tags.modify<Options & { tag?: Tag }, void>({ guildId, name, tag: { name, title, editedBy, description, image_url, footer } });
-
-            const { TagEmbedTitle, TagEmbedDescription, TagEmbedImageURL, TagEmbedFooter } = await ctx.services.tags.getValues<Options, TagResponse>({ guildId, name });
-
-            return interaction.reply({ 
-                content: `${Emojis.CHECK_MARK} Successfully edited \`${name}\`!` ,
-                embeds: [
-                    {
-                        title: TagEmbedTitle,
-                        color: 0x323338,
-                        description: TagEmbedDescription,
-                        image: { url: TagEmbedImageURL ?? undefined },
-                        footer: { text: TagEmbedFooter }
-                    }
-                ],
-                flags: MessageFlags.Ephemeral
-            })
         }
     })
 }


### PR DESCRIPTION
### Solving What’s It's Probably Causing the Unknown Interaction Events

---

During the recent rewrites, the event file responsible for handling the [`ModalSubmit`](https://discord-api-types.dev/api/discord-api-types-v10/enum/InteractionType#ModalSubmit) interaction from the `/tag edit` command got a bit messed up.

The problem lies here:  
https://github.com/JayyDoesDev/jasper/blob/3df7531e3f352d0caf86cf8c45aa466c55620302/Plugins/Tags/Modals/TagEditModal.ts?#L15-L19

The checks to filter `/tag edit` interactions and make the confirmation that the interaction type is `ModalSubmit` are fine. However, **the handling logic ended up outside the `if {}` block**, which is causing the filter to be ignored.

Since the logic isn’t properly scoped within the filter, the event file now processes **every single interaction event**, not just those related to `/tag edit`., catching interaction events it’s not supposed to handle.

If this `Plugins/Tags/Modals/TagEditModal.ts` processes an interaction first, it can block or interfere with other event files that were meant to handle those interactions. and could be the reason behind the unknown interaction events, as interactions are being caught and processed incorrectly.

---

About the database issues, these fix isn't fixing then, but, meanwhile fixing these one, I catched an error arround the `/Services/TagService.ts` that might be one of the issues around the updating tags  | database issue:
```
Uncaught exception: TypeError: Cannot use 'in' operator to search for 'method' in Error on TagEditModal TypeError: Cannot read properties of null (reading 'length')
    at TagService.modify (/home/coder/workspace/jasper-fork/dist/Services/TagService.js:106:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Object.on (/home/coder/workspace/jasper-fork/dist/Plugins/Tags/Modals/TagEditModal.js:31:17)
    at /home/coder/workspace/jasper-fork/dist/Common/types.js:5:34
    at Array.every (<anonymous>)
    at hasProperties (/home/coder/workspace/jasper-fork/dist/Common/types.js:5:17)
    at Object.on (/home/coder/workspace/jasper-fork/dist/Plugins/Core/Events/ErrorEvent.js:11:43)
    at Context.<anonymous> (/home/coder/workspace/jasper-fork/dist/Handlers/Event.js:19:65)
    at Context.emit (node:events:518:28)
    at emitUnhandledRejectionOrErr (node:events:401:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:84:21)
```

Before creating these PR, I was trying to replicate these error again to see if I find out something but I'm not able to replicate it again for some reason.

I'm will reset one more time the both redis and mongo database to see if the error replicates and start tracking possible issues.