### PR TITLE
[FIX] Duplicated Stores calls.

### DIFF
--- a/Services/Service.ts
+++ b/Services/Service.ts
@@ -18,14 +18,16 @@ interface IService {
     getMultiValues<T, R>(getMultiValues?: T):
         CommonCondition<
             R extends R[] ? R[] :
-            R extends null | undefined ? [] : R[]
+            R extends null | undefined ? [] : R[] 
         > | Promise<CommonCondition<R>>;
     deleteValue<T, R>(d: T): Promise<CommonCondition<R>> | CommonCondition<R>;
 }
 
-export abstract class Service extends Store implements IService {
+export abstract class Service implements IService {
+    protected store: Store;
+
     constructor(public readonly ctx: Context) {
-        super(ctx);
+        this.store = ctx.store;
     }
 
     public abstract configure<T>(config: T): ThisParameterType<this>;
@@ -36,8 +38,7 @@ export abstract class Service extends Store implements IService {
     public abstract getMultiValues<T, R>(getMultiValues?: T):
         CommonCondition<
             R extends R[] ? R[] :
-            R extends null | undefined ? [] : R[]
+            R extends null | undefined ? [] : R[] 
         > | Promise<CommonCondition<R>>;
     public abstract deleteValue<T, R>(d?: T): Promise<CommonCondition<R>> | CommonCondition<R>;
 }
-


### PR DESCRIPTION
Under [`Services/Service.ts`](#), the `Store` was being inicializated within the call to `super(ctx);`. 

Meanwhile, in [`Source/Context.ts`](https://github.com/JayyDoesDev/jasper/blob/8df558efb8ab260b86a9074c297d7e90bf627047/Source/Context.ts#L97), a separate `new Store()` is also being created. This duplication leads to two `Store` instances and, consequently, two separate Redis connections when the bot starts up.

https://github.com/JayyDoesDev/jasper/blob/8df558efb8ab260b86a9074c297d7e90bf627047/Source/Context.ts#L97