### PR TITLE
[FIX & ADD] Youtube Implicit TextChannel | Tag Import New Command | Tag List Pagination Fix 

### DIFF
--- a/Common/youtube.ts
+++ b/Common/youtube.ts
@@ -35,9 +35,10 @@ export async function updateSubCountChannel(ctx: Context): Promise<void> {
         numeral(json.items[0].statistics.subscriberCount).format('0.00a'),
     ).toUpperCase();
     // @ts-ignore
-    void ctx.channels.cache
-        .get(ctx.env.get('sub_count_channel'))
-        .setName(`\u{1F4FA} \u{FF5C} Sub Count: ${subscriberCount}`);
+    const channel = ctx.channels.cache.get(ctx.env.get('sub_count_channel')) as TextChannel;
+    if (channel) {
+        void channel.setName(`\u{1F4FA} \u{FF5C} Sub Count: ${subscriberCount}`);
+    }
 }
 
 // Not random

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -47,6 +47,16 @@ wrapped in `<>` while optional parameters are wrapped in `[]` brackets.
 
 > **Feature Flags**: `Modal`
 
+### `/` `tag` `import` <_json_>
+
+> **Permissions**: `STAFF_ROLE`, `ADMIN_ROLE`
+
+> **Description**: Import an tag using the json provided from `/tag raw` command.
+
+> Syntax
+
+> **Feature Flags**: `Autocomplete`
+
 ### `/` `tag` `info` <_tag_name_>
 
 > **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
@@ -67,7 +77,7 @@ wrapped in `<>` while optional parameters are wrapped in `[]` brackets.
 
 > **Permissions**: `SUPPORT_ROLE`, `STAFF_ROLE`, `ADMIN_ROLE`
 
-> **Description**: Get the raw content of a tag and sent it as an ephemeral text attachment file.
+> **Description**: Get the raw content of a tag and sent it as an ephemeral json message.
 
 > **Feature Flags**: `Autocomplete`
 

--- a/Plugins/Tags/Buttons/ListSubCommandButtons.ts
+++ b/Plugins/Tags/Buttons/ListSubCommandButtons.ts
@@ -38,7 +38,7 @@ export = {
                 embedBase.description = currentUserState.tagPages[currentUserState.page]
                     .map(
                         (e, i) =>
-                            `> **${i + 1}.** \`${e.TagName}\` **•** ${
+                            `> **${(currentUserState.page * 10) + i + 1}.** \`${e.TagName}\` **•** ${
                                 e.TagAuthor ? `<@${e.TagAuthor}>` : 'None'
                             }`,
                     )

--- a/Plugins/Tags/Buttons/ListSubCommandButtons.ts
+++ b/Plugins/Tags/Buttons/ListSubCommandButtons.ts
@@ -1,9 +1,4 @@
-import {
-    ButtonInteraction,
-    ButtonStyle,
-    ActionRowBuilder,
-    ButtonBuilder
-} from 'discord.js';
+import { ButtonInteraction, ButtonStyle, ComponentType } from 'discord.js';
 import { defineEvent } from '../../../Common/define';
 import { Context } from '../../../Source/Context';
 
@@ -15,7 +10,7 @@ export = {
         },
         on: async (interaction: ButtonInteraction, ctx: Context) => {
             if (!interaction.isButton()) return;
-            
+
             const author = interaction.user.id;
             const title = 'Server Tag List';
             const thumbnail = { url: interaction.guild.iconURL() ?? '' };
@@ -38,7 +33,7 @@ export = {
                 embedBase.description = currentUserState.tagPages[currentUserState.page]
                     .map(
                         (e, i) =>
-                            `> **${(currentUserState.page * 10) + i + 1}.** \`${e.TagName}\` **•** ${
+                            `> **${currentUserState.page * 10 + i + 1}.** \`${e.TagName}\` **•** ${
                                 e.TagAuthor ? `<@${e.TagAuthor}>` : 'None'
                             }`,
                     )
@@ -48,28 +43,38 @@ export = {
                     currentUserState.tagPages.length
                 } • emojis by AnThOnY & deussa`;
 
-                const updatedComponents = [
-                    new ActionRowBuilder<ButtonBuilder>().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId(`list_subcommand_button_previous_${interaction.user.id}`)
-                            .setStyle(ButtonStyle.Primary)
-                            .setLabel('Previous')
-                            .setDisabled(currentUserState.page === 0),
-                        new ButtonBuilder()
-                            .setCustomId(`list_subcommand_button_home_${interaction.user.id}`)
-                            .setStyle(ButtonStyle.Secondary)
-                            .setLabel('Home'),
-                        new ButtonBuilder()
-                            .setCustomId(`list_subcommand_button_next_${interaction.user.id}`)
-                            .setStyle(ButtonStyle.Primary)
-                            .setLabel('Next')
-                            .setDisabled(currentUserState.page === currentUserState.tagPages.length - 1)
-                    )
+                const components = [
+                    {
+                        type: ComponentType.ActionRow,
+                        components: [
+                            {
+                                type: ComponentType.Button,
+                                customId: `list_subcommand_button_previous_${interaction.user.id}`,
+                                style: ButtonStyle.Primary,
+                                label: 'Previous',
+                                disabled: currentUserState.page === 0,
+                            },
+                            {
+                                type: ComponentType.Button,
+                                customId: `list_subcommand_button_home_${interaction.user.id}`,
+                                style: ButtonStyle.Secondary,
+                                label: 'Home',
+                            },
+                            {
+                                type: ComponentType.Button,
+                                customId: `list_subcommand_button_next_${interaction.user.id}`,
+                                style: ButtonStyle.Primary,
+                                label: 'Next',
+                                disabled:
+                                    currentUserState.page === currentUserState.tagPages.length - 1,
+                            },
+                        ],
+                    },
                 ];
 
                 await interaction.update({
                     embeds: [embedBase],
-                    components: updatedComponents,
+                    ...components,
                 });
             };
 

--- a/Plugins/Tags/Commands/TagCommand.ts
+++ b/Plugins/Tags/Commands/TagCommand.ts
@@ -13,6 +13,7 @@ import {
     RawSubCommand,
     UseSubCommand,
     EditSubCommand,
+    ImportSubCommand,
 } from '../SubCommands';
 
 export = {
@@ -32,6 +33,7 @@ export = {
             raw: RawSubCommand,
             use: UseSubCommand,
             edit: EditSubCommand,
+            import: ImportSubCommand,
         },
         on: async (ctx: Context, interaction) => {
             if (
@@ -68,6 +70,7 @@ export = {
                 raw: RawSubCommand,
                 use: UseSubCommand,
                 edit: EditSubCommand,
+                import: ImportSubCommand,
             }[subCommand];
 
             if (!subCommandHandler?.autocomplete) {

--- a/Plugins/Tags/SubCommands/ImportSubCommand.ts
+++ b/Plugins/Tags/SubCommands/ImportSubCommand.ts
@@ -39,7 +39,9 @@ export const ImportSubCommand = defineSubCommand({
         }
 
         if (!checkRequiredVariables(data)) {
-            await interaction.editReply('> The JSON must contain at least "name" and "title" fields.');
+            await interaction.editReply(
+                '> The JSON must contain at least "name" and "title" fields.',
+            );
             return;
         }
 
@@ -76,7 +78,10 @@ export const ImportSubCommand = defineSubCommand({
             await interaction.editReply(`> The support tag \`${tagData.name}\` already exists!`);
             return;
         }
-        if (tagData.image_url && !/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i.test(tagData.image_url)) {
+        if (
+            tagData.image_url &&
+            !/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i.test(tagData.image_url)
+        ) {
             await interaction.editReply('> The provided image link is not a valid image URL!');
             return;
         }

--- a/Plugins/Tags/SubCommands/ImportSubCommand.ts
+++ b/Plugins/Tags/SubCommands/ImportSubCommand.ts
@@ -1,0 +1,113 @@
+import { ApplicationCommandOptionType } from '@antibot/interactions';
+import { Context } from '../../../Source/Context';
+import { ChatInputCommandInteraction, MessageFlags } from 'discord.js';
+import { defineSubCommand } from '../../../Common/define';
+import { Options, Tag } from '../../../Services/TagService';
+import { Emojis } from '../../../Common/enums';
+
+interface TagImportData {
+    name: string;
+    title: string;
+    description?: string | null;
+    imageUrl?: string | null;
+    footer?: string | null;
+}
+
+function checkRequiredVariables(obj: unknown): obj is TagImportData {
+    if (typeof obj !== 'object' || obj === null) return false;
+    const record = obj as Record<string, unknown>;
+    return typeof record.name === 'string' && typeof record.title === 'string';
+}
+
+export const ImportSubCommand = defineSubCommand({
+    name: 'import',
+    allowedRoles: [process.env.ADMIN_ROLE, process.env.STAFF_ROLE],
+    handler: async (ctx: Context, interaction: ChatInputCommandInteraction) => {
+        const guildId = interaction.guild.id;
+        const jsonString = interaction.options.getString('json', true);
+
+        await interaction.deferReply({
+            flags: MessageFlags.Ephemeral,
+        });
+
+        let data: unknown;
+        try {
+            data = JSON.parse(jsonString);
+        } catch (error) {
+            await interaction.editReply('> The JSON provided is invalid.');
+            return;
+        }
+
+        if (!checkRequiredVariables(data)) {
+            await interaction.editReply('> The JSON must contain at least "name" and "title" fields.');
+            return;
+        }
+
+        const tagDataInput: TagImportData = data;
+
+        const nameInput = tagDataInput.name.trim();
+        const titleInput = tagDataInput.title.trim();
+
+        if (!nameInput) {
+            await interaction.editReply('> The JSON must have a non-empty "name" field.');
+            return;
+        }
+        if (!titleInput) {
+            await interaction.editReply('> The JSON must have a non-empty "title" field.');
+            return;
+        }
+
+        const tagData: Tag = {
+            name: nameInput,
+            title: titleInput,
+            author: interaction.user.id,
+            description: tagDataInput.description ?? null,
+            image_url: tagDataInput.imageUrl ?? null,
+            footer: tagDataInput.footer ?? null,
+        };
+
+        await ctx.services.tags.configure<Options>({
+            guildId,
+            name: tagData.name,
+            tag: tagData,
+        });
+
+        if (await ctx.services.tags.itemExists<Options>()) {
+            await interaction.editReply(`> The support tag \`${tagData.name}\` already exists!`);
+            return;
+        }
+        if (tagData.image_url && !/^https?:\/\/.*\.(jpg|jpeg|png|gif|webp)$/i.test(tagData.image_url)) {
+            await interaction.editReply('> The provided image link is not a valid image URL!');
+            return;
+        }
+
+        await ctx.services.tags.create<Options & { tag: Tag }, void>();
+
+        await interaction.editReply({
+            content: `${Emojis.CHECK_MARK} Successfully imported the tag \`${tagData.name}\`!`,
+            embeds: [
+                {
+                    title: tagData.title,
+                    color: 0x323338,
+                    description: tagData.description,
+                    image: tagData.image_url ? { url: tagData.image_url } : undefined,
+                    footer: { text: tagData.footer ?? '' },
+                },
+            ],
+        });
+    },
+});
+
+export const commandOptions = {
+    name: ImportSubCommand.name,
+    description: 'Import a tag from a JSON file',
+    type: ApplicationCommandOptionType.SUB_COMMAND,
+    options: [
+        {
+            name: 'json',
+            description: 'The JSON string containing tag data',
+            type: ApplicationCommandOptionType.STRING,
+            required: true,
+        },
+    ],
+};

--- a/Plugins/Tags/SubCommands/ListSubCommand.ts
+++ b/Plugins/Tags/SubCommands/ListSubCommand.ts
@@ -66,7 +66,7 @@ export const ListSubCommand = defineSubCommand({
                     description: state.tagPages[state.page]
                         .map(
                             (e, i) =>
-                                `> **${(state.page * 10) + i + 1}.** \`${e.TagName}\` **•** ${
+                                `> **${state.page * 10 + i + 1}.** \`${e.TagName}\` **•** ${
                                     e.TagAuthor ? `<@${e.TagAuthor}>` : 'None'
                                 }`,
                         )

--- a/Plugins/Tags/SubCommands/ListSubCommand.ts
+++ b/Plugins/Tags/SubCommands/ListSubCommand.ts
@@ -66,7 +66,9 @@ export const ListSubCommand = defineSubCommand({
                     description: state.tagPages[state.page]
                         .map(
                             (e, i) =>
-                                `> **${i + 1}.** \`${e.TagName}\` **•** ${e.TagAuthor ? `<@${e.TagAuthor}>` : 'None'}`,
+                                `> **${(state.page * 10) + i + 1}.** \`${e.TagName}\` **•** ${
+                                    e.TagAuthor ? `<@${e.TagAuthor}>` : 'None'
+                                }`,
                         )
                         .join('\n'),
                     footer: {

--- a/Plugins/Tags/SubCommands/index.ts
+++ b/Plugins/Tags/SubCommands/index.ts
@@ -6,6 +6,7 @@ import { commandOptions as infoOptions, InfoSubCommand } from './InfoSubCommand'
 import { commandOptions as rawOptions, RawSubCommand } from './RawSubCommand';
 import { commandOptions as useOptions, UseSubCommand } from './UseSubCommand';
 import { commandOptions as editOptions, EditSubCommand } from './EditSubCommand';
+import { commandOptions as importOptions, ImportSubCommand } from './ImportSubCommand';
 
 export const subCommandOptions = [
     createOptions,
@@ -16,6 +17,7 @@ export const subCommandOptions = [
     rawOptions,
     useOptions,
     editOptions,
+    importOptions,
 ];
 
 export {
@@ -27,4 +29,5 @@ export {
     RawSubCommand,
     UseSubCommand,
     EditSubCommand,
+    ImportSubCommand,
 };


### PR DESCRIPTION
### [[REF] Implicit as TextChannel and check if Channel exists.](https://github.com/JayyDoesDev/jasper/pull/72/commits/7e645d2f1172e9319b0439f051334df4d3cc83d1)

- Specify TextChannel `ctx.channels.cache.get(ctx.env.get('sub_count_channel'))` instead being different types of channel:

```log
Common/youtube.ts:40:10 - error TS2339: Property 'setName' does not exist on type 'Channel'.
  Property 'setName' does not exist on type 'DMChannel'.

40         .setName(`\u{1F4FA} \u{FF5C} Sub Count: ${subscriberCount}`);
```

### [[ADD] Tag Import Command (admin/staff only)](https://github.com/JayyDoesDev/jasper/pull/72/commits/29de06e4c0ceb7a0e80afb47d33500e57d27d2d6)

- Add `/tag import <json_content>` for easilier import tag content from `/tag raw` command.
- These is an idea, that could be applied in a future to create tags from the json content of an EmbedBuilder, using like DiscoHook or some short of embed builder that return's the tag embed content as json file and imported directly.

### [[FIX] Pagination Buttons not working correctly.](https://github.com/JayyDoesDev/jasper/pull/72/commits/6eae0dbfea78cb60ee9875be40b01b6525df7ddd)

- Fix for pagination of `/tag list`. Problem was that components wasn't being updated, so the `ButtonBuilder().setDisabled()` was being disabled and not updated accordly to the pagination being updated/used.
- Also minor changes for the new syntax related to the update of ButtonBuilder & Embed, and some protections.