### PR TITLE
[FIX] Topic Subcommands and Pagination Listener Bugs

### DIFF
--- a/apps/bot/src/plugins/configuration/subcommands/removeTopicSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/removeTopicSubCommand.ts
@@ -90,6 +90,10 @@ export const RemoveTopicSubCommand = defineSubCommand({
 
         const updatedTopics = await ctx.services.settings.getTopics<string>(guildId, 'Topics');
 
+        const updatedPages = chunk(updatedTopics, 10);
+        state.addTopicPages.pages = updatedPages;
+        state.addTopicPages.page = Math.min(state.addTopicPages.page, updatedPages.length - 1);
+
         await interaction.reply({
             components,
             content: `I've removed **${topic}** from the topics list.`,

--- a/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
@@ -26,37 +26,36 @@ export const ViewTopicsSubCommand = defineSubCommand({
             return;
         }
 
-        var components;
-        if (topicsExistInDB.length === 0) {
-            components = [];
-        } else {
+        let components = [];
+        
+        if (!topicsExistInDB.length === 0) {
             components = [
-                {
-                    components: [
-                        {
-                            customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
-                            disabled: state.addTopicPages.page === 0,
-                            label: 'Previous',
-                            style: ButtonStyle.Primary as const,
-                            type: ComponentType.Button as const,
-                        },
-                        {
-                            customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
-                            label: 'Home',
-                            style: ButtonStyle.Secondary as const,
-                            type: ComponentType.Button as const,
-                        },
-                        {
-                            customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
-                            disabled:
-                                state.addTopicPages.page === state.addTopicPages.pages.length - 1,
-                            label: 'Next',
-                            style: ButtonStyle.Primary as const,
-                            type: ComponentType.Button as const,
-                        },
-                    ],
-                    type: ComponentType.ActionRow as const,
-                },
+                    {
+                        components: [
+                            {
+                                customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
+                                disabled: state.addTopicPages.page === 0,
+                                label: 'Previous',
+                                style: ButtonStyle.Primary as const,
+                                type: ComponentType.Button as const,
+                            },
+                            {
+                                customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
+                                label: 'Home',
+                                style: ButtonStyle.Secondary as const,
+                                type: ComponentType.Button as const,
+                            },
+                            {
+                                customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
+                                disabled:
+                                    state.addTopicPages.page === state.addTopicPages.pages.length - 1,
+                                label: 'Next',
+                                style: ButtonStyle.Primary as const,
+                                type: ComponentType.Button as const,
+                            },
+                        ],
+                        type: ComponentType.ActionRow as const,
+                    },
             ];
         }
 

--- a/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
+++ b/apps/bot/src/plugins/configuration/subcommands/viewTopicsSubCommand.ts
@@ -26,33 +26,39 @@ export const ViewTopicsSubCommand = defineSubCommand({
             return;
         }
 
-        const components = [
-            {
-                components: [
-                    {
-                        customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
-                        disabled: state.addTopicPages.page === 0,
-                        label: 'Previous',
-                        style: ButtonStyle.Primary as const,
-                        type: ComponentType.Button as const,
-                    },
-                    {
-                        customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
-                        label: 'Home',
-                        style: ButtonStyle.Secondary as const,
-                        type: ComponentType.Button as const,
-                    },
-                    {
-                        customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
-                        disabled: state.addTopicPages.page === state.addTopicPages.pages.length - 1,
-                        label: 'Next',
-                        style: ButtonStyle.Primary as const,
-                        type: ComponentType.Button as const,
-                    },
-                ],
-                type: ComponentType.ActionRow as const,
-            },
-        ];
+        var components;
+        if (topicsExistInDB.length === 0) {
+            components = [];
+        } else {
+            components = [
+                {
+                    components: [
+                        {
+                            customId: `add_topic_subcommand_button_previous_${interaction.user.id}`,
+                            disabled: state.addTopicPages.page === 0,
+                            label: 'Previous',
+                            style: ButtonStyle.Primary as const,
+                            type: ComponentType.Button as const,
+                        },
+                        {
+                            customId: `add_topic_subcommand_button_home_${interaction.user.id}`,
+                            label: 'Home',
+                            style: ButtonStyle.Secondary as const,
+                            type: ComponentType.Button as const,
+                        },
+                        {
+                            customId: `add_topic_subcommand_button_next_${interaction.user.id}`,
+                            disabled:
+                                state.addTopicPages.page === state.addTopicPages.pages.length - 1,
+                            label: 'Next',
+                            style: ButtonStyle.Primary as const,
+                            type: ComponentType.Button as const,
+                        },
+                    ],
+                    type: ComponentType.ActionRow as const,
+                },
+            ];
+        }
 
         await interaction.reply({
             components,
@@ -60,12 +66,12 @@ export const ViewTopicsSubCommand = defineSubCommand({
                 {
                     color: global.embedColor,
                     description:
-                        state.addTopicPages.pages[state.addTopicPages.page]
+                        (state.addTopicPages.pages[state.addTopicPages.page] || [])
                             .map(
                                 (string, i) =>
                                     `**${state.addTopicPages.page * 10 + i + 1}.** *${string}*`,
                             )
-                            .join('\n') || 'No topics',
+                            .join('\n') || 'There are no topics configured.',
                     footer: {
                         text: `Page: ${state.addTopicPages.page + 1}/${state.addTopicPages.pages.length} • Total Topics: ${topicsExistInDB.length}`,
                     },


### PR DESCRIPTION
1. In `viewTopicsSubCommand.ts`, when there was no topics in the database, these was returning `undefined` instead a `map`. Since the handling of the code was prepared to receive a mapping, these was causing `Unhandled promise rejection: TypeError: Cannot read properties of undefined (reading 'map')`


2. The interaction listener also assumed topics would always be present. To prevent the listener to be triggered when there are no topics, I added a verification step in `viewTopicsSubCommand.ts` that only adds components if the retrieved topic list is non-empty, so when there is no topics, there will be no buttons to trigger the listener.

3. After a topic is deleted, the list of topics wasn't refreshed, so the deleted topic still appears in the “remove_topic” embe after deletion.