### PR TITLE
[ENHANCEMENT] Edit + Create messages -> Cv2 | Fixed formatting

### DIFF
--- a/apps/bot/src/listeners/interactionCreateListener.ts
+++ b/apps/bot/src/listeners/interactionCreateListener.ts
@@ -5,10 +5,16 @@ import {
     ButtonStyle,
     ChatInputCommandInteraction,
     ComponentType,
+    ContainerBuilder,
     ContextMenuCommandInteraction,
     Interaction as InteractionEvent,
+    MediaGalleryBuilder,
+    MediaGalleryItemBuilder,
     MessageFlags,
     ModalSubmitInteraction,
+    SeparatorBuilder,
+    SeparatorSpacingSize,
+    TextDisplayBuilder,
 } from 'discord.js';
 
 import { Context } from '../classes/context';
@@ -165,18 +171,42 @@ export default class InteractionCreateListener extends Listener<'interactionCrea
             } else {
                 await this.ctx.services.tags.create<Options & { tag: Tag }, void>();
 
+                const confirmContent = new TextDisplayBuilder().setContent(
+                    `${Emojis.CHECK_MARK} Successfully created \`${name}\`!`,
+                );
+
+                const container = new ContainerBuilder()
+                    .setAccentColor(global.embedColor)
+                    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`### ${title}`))
+                    .addSeparatorComponents(
+                        new SeparatorBuilder()
+                            .setSpacing(SeparatorSpacingSize.Large)
+                            .setDivider(true),
+                    )
+                    .addTextDisplayComponents(
+                        new TextDisplayBuilder().setContent(`${description}`),
+                    );
+
+                if (image_url) {
+                    container.addMediaGalleryComponents(
+                        new MediaGalleryBuilder().addItems(
+                            new MediaGalleryItemBuilder().setURL(`${image_url}`),
+                        ),
+                    );
+                }
+                if (footer) {
+                    container.addSeparatorComponents(
+                        new SeparatorBuilder()
+                            .setSpacing(SeparatorSpacingSize.Small)
+                            .setDivider(true),
+                    ),
+                        container.addTextDisplayComponents(
+                            new TextDisplayBuilder().setContent(`-# ${footer}`),
+                        );
+                }
                 await interaction.reply({
-                    content: `${Emojis.CHECK_MARK} Successfully created \`${name}\`!`,
-                    embeds: [
-                        {
-                            color: 0x323338,
-                            description: description,
-                            footer: { text: footer },
-                            image: image_url ? { url: image_url } : undefined,
-                            title: title,
-                        },
-                    ],
-                    flags: MessageFlags.Ephemeral,
+                    components: [confirmContent, container],
+                    flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
                 });
             }
         }
@@ -230,18 +260,45 @@ export default class InteractionCreateListener extends Listener<'interactionCrea
                         name,
                     });
 
+                const confirmContent = new TextDisplayBuilder().setContent(
+                    `${Emojis.CHECK_MARK} Successfully edited \`${name}\`!`,
+                );
+
+                const container = new ContainerBuilder()
+                    .setAccentColor(global.embedColor)
+                    .addTextDisplayComponents(
+                        new TextDisplayBuilder().setContent(`### ${TagEmbedTitle}`),
+                    )
+                    .addSeparatorComponents(
+                        new SeparatorBuilder()
+                            .setSpacing(SeparatorSpacingSize.Large)
+                            .setDivider(true),
+                    )
+                    .addTextDisplayComponents(
+                        new TextDisplayBuilder().setContent(`${TagEmbedDescription}`),
+                    );
+
+                if (image_url) {
+                    container.addMediaGalleryComponents(
+                        new MediaGalleryBuilder().addItems(
+                            new MediaGalleryItemBuilder().setURL(`${TagEmbedImageURL}`),
+                        ),
+                    );
+                }
+                if (footer) {
+                    container.addSeparatorComponents(
+                        new SeparatorBuilder()
+                            .setSpacing(SeparatorSpacingSize.Small)
+                            .setDivider(true),
+                    ),
+                        container.addTextDisplayComponents(
+                            new TextDisplayBuilder().setContent(`-# ${TagEmbedFooter}`),
+                        );
+                }
+
                 await interaction.reply({
-                    content: `${Emojis.CHECK_MARK} Successfully edited \`${name}\`!`,
-                    embeds: [
-                        {
-                            color: 0x323338,
-                            description: TagEmbedDescription,
-                            footer: { text: TagEmbedFooter },
-                            image: { url: TagEmbedImageURL ?? undefined },
-                            title: TagEmbedTitle,
-                        },
-                    ],
-                    flags: MessageFlags.Ephemeral,
+                    components: [confirmContent, container],
+                    flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
                 });
             } catch (error) {
                 throw 'Error on TagEditModal ' + error.stack || error;

--- a/apps/bot/src/plugins/tags/commands/resolveCommand.ts
+++ b/apps/bot/src/plugins/tags/commands/resolveCommand.ts
@@ -38,15 +38,15 @@ export = {
             type: ApplicationCommandType.CHAT_INPUT,
         },
         on: async (ctx, interaction) => {
-            const container = new ContainerBuilder()
-                .setAccentColor(global.embedColor)
-                .addTextDisplayComponents(
-                    new TextDisplayBuilder().setContent(
-                        `-# Post marked as Resolved by <@${interaction.user.id}>`,
-                    ),
-                );
             const originalQuestion: string = interaction.options.getString('original_question');
             const summarizedAnswer: string = interaction.options.getString('summarized_answer');
+
+            const mentionText = new TextDisplayBuilder().setContent(
+                `Post marked as resolved by <@${interaction.user.id}>`,
+            );
+
+            const container = new ContainerBuilder().setAccentColor(global.embedColor);
+
             if (originalQuestion) {
                 container.addTextDisplayComponents(
                     new TextDisplayBuilder().setContent(
@@ -62,7 +62,7 @@ export = {
                 );
             }
             const finalReply: Record<string, any> = {
-                components: [container],
+                components: [mentionText, container],
                 flags: MessageFlags.IsComponentsV2,
             };
 

--- a/apps/bot/src/plugins/tags/subCommands/showSubCommand.ts
+++ b/apps/bot/src/plugins/tags/subCommands/showSubCommand.ts
@@ -52,9 +52,6 @@ export const ShowSubCommand = defineSubCommand({
             )
             .addTextDisplayComponents(
                 new TextDisplayBuilder().setContent(`${tag.TagEmbedDescription}`),
-            )
-            .addSeparatorComponents(
-                new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
             );
 
         if (tag.TagEmbedImageURL) {
@@ -64,9 +61,14 @@ export const ShowSubCommand = defineSubCommand({
                 ),
             );
         }
-        container.addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(`-# ${tag.TagEmbedFooter}`),
-        );
+        if (tag.TagEmbedFooter) {
+            container.addSeparatorComponents(
+                new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+            ),
+                container.addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent(`-# ${tag.TagEmbedFooter}`),
+                );
+        }
 
         await interaction.editReply({
             components: [container],
@@ -84,7 +86,7 @@ export const ShowSubCommand = defineSubCommand({
 });
 
 export const commandOptions = {
-    description: "Show a tag's content",
+    description: "Show a tag's content to yourself",
     name: ShowSubCommand.name,
     options: [
         {

--- a/apps/bot/src/plugins/tags/subCommands/useSubCommand.ts
+++ b/apps/bot/src/plugins/tags/subCommands/useSubCommand.ts
@@ -44,8 +44,9 @@ export const UseSubCommand = defineSubCommand({
         await interaction.deferReply();
         const container = new ContainerBuilder().setAccentColor(global.embedColor);
 
+        let mentionText = null;
         if (mention) {
-            container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`${mention}`));
+            mentionText = new TextDisplayBuilder().setContent(`${mention}`);
         }
 
         container
@@ -57,9 +58,6 @@ export const UseSubCommand = defineSubCommand({
             )
             .addTextDisplayComponents(
                 new TextDisplayBuilder().setContent(`${tag.TagEmbedDescription}`),
-            )
-            .addSeparatorComponents(
-                new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
             );
 
         if (tag.TagEmbedImageURL) {
@@ -69,12 +67,18 @@ export const UseSubCommand = defineSubCommand({
                 ),
             );
         }
-        container.addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(`-# ${tag.TagEmbedFooter}`),
-        );
+
+        if (tag.TagEmbedFooter) {
+            container.addSeparatorComponents(
+                new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+            ),
+                container.addTextDisplayComponents(
+                    new TextDisplayBuilder().setContent(`-# ${tag.TagEmbedFooter}`),
+                );
+        }
 
         await interaction.editReply({
-            components: [container],
+            components: mentionText ? [mentionText, container] : [container],
             flags: MessageFlags.IsComponentsV2,
         });
     },


### PR DESCRIPTION
Changes and fixes how footers, separators mentions are applied to Component v2 messages. Moved mentions above containers for better formatting.

`resolveCommand.ts` has been formatted to have the "Post marked as resolved by <user>" to be above the container just like `useSubCommand.ts`

Extended consistency towards edit and create command's messages.

When having multiple component variables you could add them just like this:
```ts
const finalReply: Record<string, any> = {
    components: [mentionText, container],
    flags: MessageFlags.IsComponentsV2,
};
``` 
which adds the two together in a single message

![image](https://github.com/user-attachments/assets/247e6bbb-b52c-4b3b-96b7-f11f3b99a846)
![image](https://github.com/user-attachments/assets/5834541e-51f5-41e6-8061-dc809a58d83d)![image](https://github.com/user-attachments/assets/f2380b40-3877-4261-8061-03aa7ad906c2)
![image](https://github.com/user-attachments/assets/63623775-42c5-4dec-b9dd-fa5af879328b)
![image](https://github.com/user-attachments/assets/f20b693e-b5f5-4d67-876d-86c046e4b037)
