### PR TITLE
[FIX] DependaBot Unable To Recognize package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/apps/bot" # Location of package manifests
+    directory: "/apps/bot/" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    directory: "/apps/bot" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
The problem from the last github action failures is that the bot package.json are now inside the `<root>/apps/bot` and not in the root folder.

Dependabot configuration was looking into root and not the new structure.