### PR TITLE
[ADD] Fun Commands Protections against attachment that are not images or non alphanumeric text.

### DIFF
--- a/apps/bot/src/plugins/fun/commands/captionCommand.ts
+++ b/apps/bot/src/plugins/fun/commands/captionCommand.ts
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType, ApplicationCommandType } from '@antibot/interactions';
-import { AttachmentBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { AttachmentBuilder, ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { Context } from '../../../classes/context';
 import { ConfigurationRoles } from '../../../container';
@@ -53,6 +53,24 @@ export = {
             const image = interaction.options.getAttachment('image', true);
             const fontSize = interaction.options.getInteger('font_size') ?? 72;
             const position = interaction.options.getString('position') ?? 'top';
+
+            const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+            const contentType = image.contentType?.toLowerCase() ?? '';
+            if (!allowedTypes.includes(contentType)) {
+                return interaction.reply({
+                    content: 'Please upload a valid image (JPEG, PNG or WebP).',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
+            const textRegex = /^[a-zA-Z0-9\s.,!?'"@#$%&()*\-_:;\/\\]+$/;
+            if (!textRegex.test(text.trim())) {
+                return interaction.reply({
+                    content:
+                        'Please use only alphanumeric characters and basic punctuation in the top text.',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
 
             try {
                 await interaction.deferReply();

--- a/apps/bot/src/plugins/fun/commands/memeCommand.ts
+++ b/apps/bot/src/plugins/fun/commands/memeCommand.ts
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType, ApplicationCommandType } from '@antibot/interactions';
-import { AttachmentBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { AttachmentBuilder, ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { Context } from '../../../classes/context';
 import { ConfigurationRoles } from '../../../container';
@@ -43,6 +43,35 @@ export = {
             const bottomtext = interaction.options.getString('bottomtext', true) ?? '';
             const image = interaction.options.getAttachment('image', true);
             const fontSize = interaction.options.getInteger('font_size') ?? 72;
+
+            const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+            const contentType = image.contentType?.toLowerCase() ?? '';
+            if (!allowedTypes.includes(contentType)) {
+                return interaction.reply({
+                    content: 'Please upload a valid image (JPEG, PNG or WebP).',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
+            const textRegex = /^[a-zA-Z0-9\s.,!?'"@#$%&()*\-_:;\/\\]+$/;
+            const top = toptext.trim();
+            const bottom = bottomtext.trim();
+
+            if (!textRegex.test(top)) {
+                return interaction.reply({
+                    content:
+                        'Please use only alphanumeric characters and basic punctuation in the top text.',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
+            if (!textRegex.test(bottom)) {
+                return interaction.reply({
+                    content:
+                        'Please use only alphanumeric characters and basic punctuation in the bottom text.',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
 
             try {
                 await interaction.deferReply();

--- a/apps/bot/src/plugins/fun/commands/speechBubbleCommand.ts
+++ b/apps/bot/src/plugins/fun/commands/speechBubbleCommand.ts
@@ -1,5 +1,5 @@
 import { ApplicationCommandOptionType, ApplicationCommandType } from '@antibot/interactions';
-import { AttachmentBuilder, ChatInputCommandInteraction } from 'discord.js';
+import { AttachmentBuilder, ChatInputCommandInteraction, MessageFlags } from 'discord.js';
 
 import { Context } from '../../../classes/context';
 import { ConfigurationRoles } from '../../../container';
@@ -40,8 +40,18 @@ export = {
             const image = interaction.options.getAttachment('image', true);
             const position = interaction.options.getString('position') ?? 'top';
 
+            const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+            const contentType = image.contentType?.toLowerCase() ?? '';
+            if (!allowedTypes.includes(contentType)) {
+                return interaction.reply({
+                    content: 'Please upload a valid image (JPEG, PNG or WebP).',
+                    flags: MessageFlags.Ephemeral,
+                });
+            }
+
             try {
                 await interaction.deferReply();
+
                 const response = await ctx.webserver.request(
                     'POST',
                     '/fun/speechbubble',


### PR DESCRIPTION
Added something to check if the provided attachment are image as well if the text are or non alphanumeric text:
```js
const textRegex = /^[a-zA-Z0-9\s.,!?'"@#$%&()*\-_:;\/\\]+$/;
const top = toptext.trim();
const bottom = bottomtext.trim();

if (!textRegex.test(top)) {
    return interaction.reply({
        content:
            'Please use only alphanumeric characters and basic punctuation in the top text.',
        flags: MessageFlags.Ephemeral,
    });
}

if (!textRegex.test(bottom)) {
    return interaction.reply({
        content:
            'Please use only alphanumeric characters and basic punctuation in the bottom text.',
        flags: MessageFlags.Ephemeral,
    });
}
```